### PR TITLE
Blocked user routes to /error

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -68,6 +68,7 @@ app.use("/restricted", isAuthorised, require("./routes/root"));
 app.use('/api/car', require('./routes/api/car'));
 app.use('/api/users', userRoutes.router); // This can't be required directly, because of the oAuthServer
 app.use('/ethTest', require('./routes/ethTest'));
+app.use('/error', require("./routes/root"));
 
 // catch 404 and forward to error handler
 app.use((req, res, next) => {

--- a/src/authorisation/routeMethods.js
+++ b/src/authorisation/routeMethods.js
@@ -195,7 +195,7 @@ function isAuthorised(req, res, next) {
                 if (result.length === 0)
                     errorHandling(res, 403, "No result from user authorization");
                 else {
-                    if (result[0] === false)
+                    if (result[0] === true)
                         errorHandling(res, 401, "User is blocked");
                     else {
                         const body = {

--- a/src/authorisation/routeMethods.js
+++ b/src/authorisation/routeMethods.js
@@ -181,7 +181,7 @@ let app;
 //FIXME: Das herumreichen der "app" Instanz ist sehr unschön.
 // success ist die Funktion, die aufgerufen wird, wenn die Authorisierung geglückt ist.
 // TODO: Fehlerfälle
-function isAuthorised(req, res, success) {
+function isAuthorised(req, res, next) {
     const token = req.get("Authorization").slice("Bearer ".length)
 
     if (token != null) {
@@ -203,8 +203,7 @@ function isAuthorised(req, res, success) {
                             blocked: result[0],
                             authorityLevel: result[2],
                             expiration: result[3]
-                        };
-                        const msg = JSON.stringify({body});
+                        }
                         res.json(body);
                     }
                 }
@@ -220,7 +219,17 @@ function errorHandling(response, status, message)
 {
     console.log(message);
     response.status(status);
-    response.redirect('/');
+
+    const url = require('url');
+    const query = url.format({
+        pathname: '/error',
+        query: {
+        "status": status,
+        "message": message
+        }
+    });
+
+    response.redirect(query);
 }
 
 module.exports = {

--- a/src/database/dbHelper.js
+++ b/src/database/dbHelper.js
@@ -113,6 +113,7 @@ function checkUserAuthorization(token, callback) {
     const sqlCallback = (err, result) => {
         if (result == null || result.length === 0) {
             console.log("Could not find user by bearerToken: ", token);
+            callback(err, result);
         }
         else {
             callback(err, result);

--- a/src/routes/root.js
+++ b/src/routes/root.js
@@ -11,5 +11,16 @@ router.get('/', (req, res, next) => {
 /* POST to validate accessToken */
 router.post("/enter", restrictedAreaRoutesMethods.accessRestrictedArea);
 
+router.get('/error', (req, res, next) => {
+  let uri =  decodeURIComponent(req.url).toString();
+  uri = uri.slice('/error?status='.length);
+  let status = uri.substring(0, 3);
+  let message  = uri.substring(uri.indexOf('=', 1) + 1, uri.length);
+
+  res.json({
+  'status': status,
+  'message': message
+  });
+});
 
 module.exports = router;


### PR DESCRIPTION
1. Neue Route "/error" im root.js:
- JSON-Objekt wird ausgegeben mit Status und Message
- Message soll nicht in der Console stehen, sondern für die GUI erreichbar sein

2. Geblocketer User wirft eine Fehlermeldung, siehe 1

3. Callback für checkUserAuthorization im Fehlerfall eingebaut, sonst kommt kein Response zurück und "/error" wird nie erreicht